### PR TITLE
publish to legacy sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,7 @@ ThisBuild / developers := List(
   tlGitHubDev("samspills", "Sam Pillsworth")
 )
 
-// publish to s01.oss.sonatype.org (set to true to publish to oss.sonatype.org instead)
-ThisBuild / tlSonatypeUseLegacyHost := false
+ThisBuild / tlSonatypeUseLegacyHost := true // publish to oss.sonatype.org
 
 // publish website from this branch
 ThisBuild / tlSitePublishBranch := Some("main")


### PR DESCRIPTION
I think we want the legacy host (this matches vault4s and cosmos4s)