### PR TITLE
add trailing slash to pages link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Implement scalafix rules that mimic some semgrep checks.
 
-Check out the microsite for more information: https://banno.github.io/semgrep-scalafix
+Check out the microsite for more information: https://banno.github.io/semgrep-scalafix/
 
 To use the latest version, include the following in your `build.sbt`:
 


### PR DESCRIPTION
without the trailing slash redirects to the old private page, including the slash takes us correctly to the public page 