### PR TITLE
bump base version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.1" // your current series x.y
+ThisBuild / tlBaseVersion := "0.2" // your current series x.y
 
 ThisBuild / organization := "com.banno"
 ThisBuild / organizationName := "Jack Henry & Associates, Inc.®"


### PR DESCRIPTION
I'm thinking that to be on the safe side the next release should be v0.2 b/c of the bump to scalafix. I should have bumped this value as part of #31 but I didn't think of it then